### PR TITLE
turn on http-client logging

### DIFF
--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,3 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = ALL
+com.google.api.client.http.level = ALL

--- a/start.sh
+++ b/start.sh
@@ -27,4 +27,5 @@ else
     source "${APP_DIR}/app_env"
 fi
 
-exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/lfp-pay-web.jar"
+#exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/lfp-pay-web.jar"
+exec java ${JAVA_MEM_ARGS} -Djava.util.logging.config.file=${APP_DIR}/logging.properties -jar -Dserver.port="${PORT}" "${APP_DIR}/lfp-pay-web.jar"


### PR DESCRIPTION
Due to issues in live with creating a payment session from the lfp service, this PR turns on logging for the http-client as per https://www.baeldung.com/google-http-client#logging