### PR TITLE
Add query paramater to skip summary page when calling payments service

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/ViewPenaltiesController.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/ViewPenaltiesController.java
@@ -123,8 +123,9 @@ public class ViewPenaltiesController extends BaseController {
         }
 
         try {
+            // Return the payment session URL and add query parameter to indicate Review Payments screen isn't wanted
             return UrlBasedViewResolver.REDIRECT_URL_PREFIX +
-                    paymentService.createPaymentSession(payableLateFilingPenaltySession, companyNumber);
+                    paymentService.createPaymentSession(payableLateFilingPenaltySession, companyNumber) + "?summary=false";
         } catch (ServiceException e) {
 
             LOGGER.errorRequest(request, e.getMessage(), e);

--- a/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/ViewPenaltiesControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/ViewPenaltiesControllerTest.java
@@ -75,6 +75,7 @@ public class ViewPenaltiesControllerTest {
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
     private static final String REDIRECT_PATH = "redirect:";
     private static final String MOCK_PAYMENTS_URL = "pay.companieshouse/payments/987654321987654321/pay";
+    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
 
     @BeforeEach
     private void setup() {
@@ -179,7 +180,7 @@ public class ViewPenaltiesControllerTest {
 
         this.mockMvc.perform(post(VIEW_PENALTIES_PATH))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(REDIRECT_PATH + MOCK_PAYMENTS_URL));
+                .andExpect(view().name(REDIRECT_PATH + MOCK_PAYMENTS_URL + SUMMARY_FALSE_PARAMETER));
 
         verify(mockLateFilingPenaltyService, times(1)).getLateFilingPenalties(COMPANY_NUMBER, PENALTY_NUMBER);
         verify(mockPayableLateFilingPenaltyService, times(1))


### PR DESCRIPTION
Send flag to payments service to redirect directly to GovPay