### PR TITLE
add header fragment that redirects banner link to LFP app

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" class="govuk-template">
+<head>
+    <title>Header</title>
+</head>
+<body class="govuk-template__body">
+<th:block th:fragment="header">
+    <a href="#content" class="govuk-skip-link">Skip to main content</a>
+    <header role="banner" id="global-header" class="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+            <div class="header-global">
+                <div class="govuk-header__logo">
+                    <a href="/" title="Go to the companies house homepage" id="logo" class="govuk-header__link govuk-header__link--homepage">
+                        <span class="govuk-header__logotype-text"> Companies House </span>
+                    </a>
+                </div>
+            </div>
+
+            <div class="govuk-header__content"
+                 th:if="${headerText != null}">
+                <a id="proposition-name" href="/late-filing-penalty" class="govuk-header__link govuk-header__link--service-name"  th:text='${headerText}'></a>
+            </div>
+
+        </div>
+    </header>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -10,7 +10,7 @@
         <div class="govuk-header__container govuk-width-container">
             <div class="header-global">
                 <div class="govuk-header__logo">
-                    <a href="/" title="Go to the companies house homepage" id="logo" class="govuk-header__link govuk-header__link--homepage">
+                    <a href="/" title="Go to the Companies House homepage" id="logo" class="govuk-header__link govuk-header__link--homepage">
                         <span class="govuk-header__logotype-text"> Companies House </span>
                     </a>
                 </div>


### PR DESCRIPTION
pulled the header fragment out of common web java and changed the href to /late-filing-penalty for gds assessment