### PR TITLE
Upgrade library to use new fine grain scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <common-web-java.version>1.2.0-rc4</common-web-java.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <web-security-java.version>1.1.0-rc1</web-security-java.version>
+        <web-security-java.version>1.3.8</web-security-java.version>
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
         <sdk-manager-java.version>1.5.2</sdk-manager-java.version>


### PR DESCRIPTION
This new version of the `web-security-java` handles the new fine grain scopes (when the relevant feature flag is on)

Resolves FA-867