### PR TITLE
Bump web-security-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <common-web-java.version>1.5.0</common-web-java.version>
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
-        <web-security-java.version>1.3.8</web-security-java.version>
+        <web-security-java.version>1.3.10</web-security-java.version>
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
         <sdk-manager-java.version>1.5.2</sdk-manager-java.version>


### PR DESCRIPTION
This version removes the USE_FINE_GRAIN_SCOPES_MODEL feature flag

FA-1072
