### PR TITLE
Add functionality to return user back to previous page after error throws

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/SignOutController.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/SignOutController.java
@@ -90,7 +90,7 @@ public class SignOutController extends BaseController {
             LOGGER.info("radio: " + valueGet);
             redirectAttributes.addFlashAttribute("errorMessage", true);
             redirectAttributes.addFlashAttribute(BACK_BUTTON, url);
-            return new RedirectView(SIGN_OUT_URL);
+            return new RedirectView(SIGN_OUT_URL, true, false);
         }
         if (valueGet.equals("yes")) {
             return new RedirectView(ACCOUNT_URL + "/signout");


### PR DESCRIPTION
Resolves [BI-11813](https://companieshouse.atlassian.net/browse/BI-11813)

When the user does not select an action in the sign out page, it shows an error. Once this error is shown, the user can now click the back button to return them to the previous page.