### PR TITLE
Add Matomo tracking to sign out confirmation page link and radio buttons

### DIFF
--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -44,7 +44,7 @@
                 <ul class="js-signout" id="signout-navigation">
                     <li class="content-email" id="signed-in-user" th:text="${userEmail}"></li>
                     <li class="content">
-                        <a href="/late-filing-penalty/sign-out" id="user-signout">Sign out</a>
+                        <a href="/late-filing-penalty/sign-out" id="user-signout" data-event-id="sign-out-button-selected">Sign out</a>
                     </li>
                 </ul>
             </div>

--- a/src/main/resources/templates/lfp/signOut.html
+++ b/src/main/resources/templates/lfp/signOut.html
@@ -47,13 +47,13 @@
             </div>
             <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="yes-sign-out" name="radio" type="radio" value="yes">
+                    <input class="govuk-radios__input" id="yes-sign-out" name="radio" type="radio" value="yes" data-event-id="yes-to-signout">
                     <label class="govuk-label govuk-radios__label" for="yes-sign-out">
                         Yes
                     </label>
                 </div>
                 <div class="govuk-radios__item">
-                    <input class="govuk-radios__input" id="no-sign-out" name="radio" type="radio" value="no">
+                    <input class="govuk-radios__input" id="no-sign-out" name="radio" type="radio" value="no" data-event-id="no-to-signout">
                     <label class="govuk-label govuk-radios__label" for="no-sign-out">
                         No
                     </label>


### PR DESCRIPTION
Resolves [BI-11430](https://companieshouse.atlassian.net/browse/BI-11430) and [BI-11615](https://companieshouse.atlassian.net/browse/BI-11615)

- Add Matomo tracking to sign out confirmation page link and on radio buttons sign out the confirmation page