### PR TITLE
BI-12481-remove idle signout scripts

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/LFPStartController.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/controller/lfp/LFPStartController.java
@@ -46,6 +46,7 @@ public class LFPStartController extends BaseController {
         try {
             financeHealthcheck = lateFilingPenaltyService.checkFinanceSystemAvailableTime();
         } catch (ServiceException ex) {
+            LOGGER.error(ex.getMessage(), ex);
             return ERROR_VIEW;
         }
 

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -15,9 +15,6 @@
     <link
             th:href="@{{cdnUrl}/stylesheets/govuk-frontend/v3.11.0/govuk-frontend-3.11.0.min.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
             media="all" rel="stylesheet" type="text/css" />
-    <link 
-            th:href="@{{cdnUrl}/stylesheets/session-timeout.css(cdnUrl=${@environment.getProperty('cdn.url')})}" 
-            media="all" rel="stylesheet" type="text/css" />
     <link
             rel="icon"
             th:href="@{{cdnUrl}/images/favicon.ico?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
@@ -34,7 +31,6 @@
 <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
 <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
 <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/app/session-timeout.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
 
 <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
 


### PR DESCRIPTION
Resolves [BI-12481](https://companieshouse.atlassian.net/browse/BI-12481)


-  Remove the idle sign out functionality by removing call to cdn script
- As an add on to previous work in [BI-12376-](https://github.com/companieshouse/lfp-pay-web/pull/131)  add extra log message to ensure that service exception is logged on start controller if issue with connecting to financial service. 

[BI-12481]: https://companieshouse.atlassian.net/browse/BI-12481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ