### PR TITLE
IE-254 Fix issue with handling empty date strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <structured-logging.version>1.9.12</structured-logging.version>
         <log4j-bom.version>2.17.0</log4j-bom.version>
         <common-web-java.version>1.5.0</common-web-java.version>
-        <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
+        <thymeleaf-layout-dialect.version>3.2.1</thymeleaf-layout-dialect.version>
         <java-session-handler.version>2.2.0</java-session-handler.version>
         <web-security-java.version>1.3.10</web-security-java.version>
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
@@ -29,9 +29,9 @@
 
 
 
-        <spring-boot-dependencies.version>2.4.13</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.11</spring-boot-dependencies.version>
         <spring-test.version>5.2.3.RELEASE</spring-test.version>
-        <spring-boot-maven-plugin.version>2.4.13</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>2.7.11</spring-boot-maven-plugin.version>
         <json.version>20211205</json.version>
         <!-- Maven and Surefire plugins -->
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <spring-boot-dependencies.version>2.7.11</spring-boot-dependencies.version>
         <spring-test.version>5.2.3.RELEASE</spring-test.version>
         <spring-boot-maven-plugin.version>2.7.11</spring-boot-maven-plugin.version>
-        <json.version>20211205</json.version>
+        <json.version>20231013</json.version>
         <!-- Maven and Surefire plugins -->
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/IE-254

The app was using jackson-databind 2.11 (from Spring) and jackson-datatype-jsr310 2.12 (from structured-logging). These two jackson packages calls each other so the difference caused an issue where jsr310 called a method that didn't exist in databind.

Updated the Spring version so the versions of jackson is compatible.