### PR TITLE
Feature/fix sonarqube vulnerabilites may 2024

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
@@ -1,5 +1,5 @@
 package uk.gov.companieshouse.web.lfp.security;
-
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -9,56 +9,43 @@ import uk.gov.companieshouse.auth.filter.HijackFilter;
 import uk.gov.companieshouse.auth.filter.UserAuthFilter;
 import uk.gov.companieshouse.session.handler.SessionHandler;
 
-@SuppressWarnings("java:S1118")  // Constructor is required for Spring Application
+@SuppressWarnings("java:S1118")
 @EnableWebSecurity
 public class WebSecurity {
-
+    @Bean
     @Order(1)
     public SecurityFilterChain temporaryStartPageSecurityFilterChain(HttpSecurity http) throws Exception {
         http
-                .antMatcher("/late-filing-penalty")
-                .authorizeRequests(authorize -> authorize
-                        .anyRequest().authenticated()
-                );
+                .antMatcher("/late-filing-penalty");
         return http.build();
     }
 
-
-
+    @Bean
     @Order(2)
-    protected SecurityFilterChain accessibilityStatementPageSecurityConfig(HttpSecurity http) throws Exception {
+        protected SecurityFilterChain accessibilityStatementPageSecurityConfig(HttpSecurity http) throws Exception {
         http
-                .antMatcher("/late-filing-penalty/accessibility-statement")
-                .authorizeRequests(authorize -> authorize
-                        .anyRequest().authenticated()
-                );
+                .antMatcher("/late-filing-penalty/accessibility-statement");
         return http.build();
     }
 
-
+    @Bean
     @Order(3)
-    protected SecurityFilterChain healthcheckSecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .antMatcher("/late-filing-penalty/healthcheck")
-                .authorizeRequests(authorize -> authorize
-                        .anyRequest().authenticated()
-                );
+        protected SecurityFilterChain healthcheckSecurityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .antMatcher("/late-filing-penalty/healthcheck");
         return http.build();
     }
 
-
+    @Bean
     @Order(4)
-    public SecurityFilterChain lFPWebSecurityFilterConfig (HttpSecurity http) throws Exception {
-        http
-                .antMatcher("/late-filing-penalty/**")
-                .addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class)
-                .addFilterBefore(new HijackFilter(), BasicAuthenticationFilter.class)
-                .addFilterBefore(new UserAuthFilter(), BasicAuthenticationFilter.class)
-                .authorizeRequests(authorize -> authorize
-                        .anyRequest().authenticated()
-                );
-        return http.build();
-    }
+        public SecurityFilterChain lFPWebSecurityFilterConfig (HttpSecurity http) throws Exception {
+            http
+                    .antMatcher("/late-filing-penalty/**")
+                    .addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class)
+                    .addFilterBefore(new HijackFilter(), BasicAuthenticationFilter.class)
+                    .addFilterBefore(new UserAuthFilter(), BasicAuthenticationFilter.class);
 
+            return http.build();
+        }
 }
 

--- a/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.web.lfp.security;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -9,8 +11,9 @@ import uk.gov.companieshouse.auth.filter.HijackFilter;
 import uk.gov.companieshouse.auth.filter.UserAuthFilter;
 import uk.gov.companieshouse.session.handler.SessionHandler;
 
-@SuppressWarnings("java:S1118")
+@Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class WebSecurity {
     @Bean
     @Order(1)

--- a/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/web/lfp/security/WebSecurity.java
@@ -1,10 +1,9 @@
 package uk.gov.companieshouse.web.lfp.security;
 
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 import uk.gov.companieshouse.auth.filter.HijackFilter;
 import uk.gov.companieshouse.auth.filter.UserAuthFilter;
@@ -14,52 +13,51 @@ import uk.gov.companieshouse.session.handler.SessionHandler;
 @EnableWebSecurity
 public class WebSecurity {
 
-    @Configuration
     @Order(1)
-    public static class TemporaryStartPageSecurityConfig extends WebSecurityConfigurerAdapter {
-
-        @Override
-        protected void configure(HttpSecurity http) throws Exception {
-            http
-                    .antMatcher("/late-filing-penalty");
-        }
+    public SecurityFilterChain temporaryStartPageSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .antMatcher("/late-filing-penalty")
+                .authorizeRequests(authorize -> authorize
+                        .anyRequest().authenticated()
+                );
+        return http.build();
     }
 
 
-    @Configuration
+
     @Order(2)
-    public static class AccessibilityStatementPageSecurityConfig extends WebSecurityConfigurerAdapter {
-
-        @Override
-        protected void configure(HttpSecurity http) throws Exception {
-            http
-                    .antMatcher("/late-filing-penalty/accessibility-statement");
-        }
+    protected SecurityFilterChain accessibilityStatementPageSecurityConfig(HttpSecurity http) throws Exception {
+        http
+                .antMatcher("/late-filing-penalty/accessibility-statement")
+                .authorizeRequests(authorize -> authorize
+                        .anyRequest().authenticated()
+                );
+        return http.build();
     }
 
 
-    @Configuration
     @Order(3)
-    public static class HealthcheckSecurityConfig extends WebSecurityConfigurerAdapter {
-
-        @Override
-        protected void configure(HttpSecurity http) throws Exception {
-            http.antMatcher("/late-filing-penalty/healthcheck");
-        }
+    protected SecurityFilterChain healthcheckSecurityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .antMatcher("/late-filing-penalty/healthcheck")
+                .authorizeRequests(authorize -> authorize
+                        .anyRequest().authenticated()
+                );
+        return http.build();
     }
 
-    @Configuration
+
     @Order(4)
-    public static class LFPWebSecurityFilterConfig extends WebSecurityConfigurerAdapter {
-
-        @Override
-        protected void configure(HttpSecurity http) throws Exception {
-
-            http.antMatcher("/late-filing-penalty/**")
-                    .addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class)
-                    .addFilterBefore(new HijackFilter(), BasicAuthenticationFilter.class)
-                    .addFilterBefore(new UserAuthFilter(), BasicAuthenticationFilter.class);
-        }
+    public SecurityFilterChain lFPWebSecurityFilterConfig (HttpSecurity http) throws Exception {
+        http
+                .antMatcher("/late-filing-penalty/**")
+                .addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class)
+                .addFilterBefore(new HijackFilter(), BasicAuthenticationFilter.class)
+                .addFilterBefore(new UserAuthFilter(), BasicAuthenticationFilter.class)
+                .authorizeRequests(authorize -> authorize
+                        .anyRequest().authenticated()
+                );
+        return http.build();
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/LFPStartControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/lfp/controller/lfp/LFPStartControllerTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.lfp.exception.ServiceException;
+import uk.gov.companieshouse.web.lfp.security.WebSecurity;
 import uk.gov.companieshouse.web.lfp.service.latefilingpenalty.LateFilingPenaltyService;
 import uk.gov.companieshouse.web.lfp.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.lfp.util.LFPTestUtility;
@@ -33,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import({WebSecurity.class})
 class LFPStartControllerTest {
 
     private MockMvc mockMvc;


### PR DESCRIPTION
Resolves [DEBT-1991](https://companieshouse.atlassian.net/browse/DEBT-1991)
According to Sonarqube, there were 4 code smells on the service due to a deprecated class in Spring web security. The solution was to refactor the code to [remove the WebSecurityConfigurerAdapter ](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter) and instead register a Security Filter Chain beans for each endpoint. 


[DEBT-1991]: https://companieshouse.atlassian.net/browse/DEBT-1991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ